### PR TITLE
Ensure that a stack.yaml is specified before running

### DIFF
--- a/src/Stack/Tag.hs
+++ b/src/Stack/Tag.hs
@@ -81,6 +81,7 @@ stackTag :: StackTagOpts -> IO ()
 stackTag = runReaderT (runStackTag app)
  where
   app = do chkStackCompatible
+           chkIsStack
            sources     <- stkPaths
            depSources  <- stkDepSources
            tagSources sources depSources
@@ -99,6 +100,16 @@ p = io . putStrLn
 runStk :: [String] -> IO (ExitCode, String, String)
 runStk args
   = readProcessWithExitCode "stack" args []
+
+chkIsStack :: StackTag ()
+chkIsStack = do
+  StackTagOpts {optsStackYaml=stackYaml} <- ask
+  sYaml <- io $ doesFileExist "stack.yaml"
+
+  case stackYaml of
+    Nothing -> unless sYaml $ error "stack.yaml not found or specified!"
+    _ -> return ()
+
 
 --- | Check whether the current version of stack
 -- is compatible by trying to run `stack list-depenencies --help`.


### PR DESCRIPTION
Currently, if I run `stack-tag` in a directory that doesn't have a `stack.yaml`, it still runs and generates an empty TAGS file. This change ensures that either, 1) the current directory contains a `stack.yaml` or that 2) a `stack.yaml` was specified using the `--stack-yaml` command line option.
