### PR TITLE
Check for hasktags executable before tagging starts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,8 @@ build:
 test:
 	stack test
 
+clean:
+	stack clean
+
 TAGS: build
 	$(STKTAG)

--- a/src/Stack/Tag.hs
+++ b/src/Stack/Tag.hs
@@ -81,6 +81,7 @@ stackTag :: StackTagOpts -> IO ()
 stackTag = runReaderT (runStackTag app)
  where
   app = do chkStackCompatible
+           chkHaskTags
            chkIsStack
            sources     <- stkPaths
            depSources  <- stkDepSources
@@ -110,6 +111,12 @@ chkIsStack = do
     Nothing -> unless sYaml $ error "stack.yaml not found or specified!"
     _ -> return ()
 
+chkHaskTags :: StackTag ()
+chkHaskTags = do
+  ht <- io $ findExecutable "hasktags"
+  case ht of
+    Just p -> return ()
+    Nothing -> error "You must have hasktags installed Run 'stack install hasktags'."
 
 --- | Check whether the current version of stack
 -- is compatible by trying to run `stack list-depenencies --help`.


### PR DESCRIPTION
Otherwise it still tries to tag every package but just prints errors - this let's you know beforehand.
